### PR TITLE
[DPE-7395] - Add vulnerability scanning and SBOM generation in CI

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,82 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Trivy Security Scanner
+on:
+  push:
+    branches:
+      - 3.5/edge
+  pull_request:
+
+permissions:
+  contents: read # Set the GITHUB_TOKEN permissions to read-only
+
+jobs:
+  build:
+    name: Build rock
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.0.0
+  scan:
+    name: Trivy scan and SBOM Generation
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install required dependencies
+        run: |
+          # rockcraft
+          sudo snap install rockcraft --classic --edge
+
+          # yq
+          sudo snap install yq
+
+      - name: Download rock package(s)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+
+      - name: Import locally
+        run: |
+          full_version="$(cat rockcraft.yaml | yq .version)"
+          sudo rockcraft.skopeo --insecure-policy \
+              copy \
+              oci-archive:charmed-etcd_${full_version}_amd64.rock \
+              docker-daemon:trivy/charmed-etcd:test
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'trivy/charmed-etcd:test'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'MEDIUM,HIGH,CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+  sbom:
+    name: Trivy SBOM and Dependency Upload
+    needs: scan
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Run Trivy in GitHub SBOM mode and submit to Dependency Graph
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'image'
+          format: 'spdx-json'
+          output: 'dependency-results.sbom.json'
+          image-ref: 'trivy/charmed-etcd:test'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+          severity: 'MEDIUM,HIGH,CRITICAL'
+          scanners: 'vuln'
+
+      - name: Upload trivy report as a Github artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-sbom-report
+          path: '${{ github.workspace }}/dependency-results.sbom.json'
+          retention-days: 90

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,7 +4,7 @@ name: Trivy Security Scanner
 on:
   push:
     branches:
-      - 3.5/edge
+      - 3.6/edge
   pull_request:
 
 permissions:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Run Trivy in GitHub SBOM mode and submit to Dependency Graph
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: 'image'
           format: 'spdx-json'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.0.0
   scan:
-    name: Trivy scan and SBOM Generation
+    name: Trivy scan
     needs: build
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for security scanning and SBOM (Software Bill of Materials) generation using Trivy. The workflow includes steps for scanning vulnerabilities, generating SBOMs, and integrating results into GitHub's Security and Dependency Graph features.

### Security Scanning Workflow:

* [`.github/workflows/trivy.yaml`](diffhunk://#diff-86074bc26083ca63c88e706d230f9cfebe66f21be849a202ed1fbd450a0c0996R1-R82): Added a new workflow named "Trivy Security Scanner" to automate vulnerability scanning and SBOM generation. It includes two jobs: `build` (to prepare rock packages) and `scan` (to run Trivy and upload results to GitHub Security tab).

### SBOM Generation and Integration:

* [`.github/workflows/trivy.yaml`](diffhunk://#diff-86074bc26083ca63c88e706d230f9cfebe66f21be849a202ed1fbd450a0c0996R1-R82): Added a job named `sbom` to generate SBOMs in SPDX JSON format using Trivy and upload dependency data to GitHub's Dependency Graph. Results are also stored as artifacts for future reference.