### PR TITLE
Remove permissions field from trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,9 +7,6 @@ on:
       - 3.6/edge
   pull_request:
 
-permissions:
-  contents: read # Set the GITHUB_TOKEN permissions to read-only
-
 jobs:
   build:
     name: Build rock


### PR DESCRIPTION
This pull request removes the `permissions` section from the `.github/workflows/trivy.yaml` file.