### PR TITLE
fix: Fuse sbom and vulnerability scanning steps into same job

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -42,7 +42,7 @@ jobs:
               docker-daemon:trivy/charmed-etcd:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: 'trivy/charmed-etcd:test'
           format: 'sarif'
@@ -56,7 +56,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: 'image'
           format: 'spdx-json'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -54,14 +54,9 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
-  sbom:
-    name: Trivy SBOM and Dependency Upload
-    needs: scan
-    if: github.event_name == 'push'
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Run Trivy in GitHub SBOM mode and submit to Dependency Graph
-        uses: aquasecurity/trivy-action@0.31.0
+
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
+        uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'image'
           format: 'spdx-json'


### PR DESCRIPTION
Updates to Trivy configuration:

* [`.github/workflows/trivy.yaml`](diffhunk://#diff-86074bc26083ca63c88e706d230f9cfebe66f21be849a202ed1fbd450a0c0996L57-R58): Simplified the SBOM configuration by removing redundant steps and ensuring results are submitted directly to the Dependency Graph.