### PR TITLE
[DPE-7868] Make release tag flexible

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,5 @@
 name: Publish to GHCR
 
-env:
-  RELEASE: edge
-
 on:
   push:
     branches:
@@ -20,6 +17,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Extract branch name
+        shell: bash
+        run: |
+          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "risk=${BRANCH##*\/}" >> $GITHUB_OUTPUT
+        id: extract_branch
       - name: Setup Docker
         run: |
           sudo snap install docker
@@ -47,7 +51,8 @@ jobs:
           version="$(yq .version rockcraft.yaml)"
           base=$(yq .base rockcraft.yaml)
           base="${base#*@}"
-          tag=${version}-${base}-${{ env.RELEASE }}
+          risk=${{ steps.extract_branch.outputs.risk }}
+          tag=${version}-${base}_${risk}
 
           echo "Publishing charmed-etcd:${tag}"
           sudo rockcraft.skopeo --insecure-policy copy \


### PR DESCRIPTION
This PR adjusts the release workflow and extracts the "risk" from the branch name, adding it to image tag before pushing to GHCR. By that, we can make the release tag flexible and have automated releases per branch name, e.g. PR's to the `3.6-24.04/edge` branch will release with `_edge` and PR's to `3.6-24.04/beta` will release with `_beta`.

Syntax check:

```
$ BRANCH="3.6-24.04/edge"
$ echo "risk=${BRANCH##*\/}"
risk=edge
$ BRANCH="3.6-24.04/beta"
$ echo "risk=${BRANCH##*\/}"
risk=beta
```

Based on https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions.