### PR TITLE
[DPE-7868] add release workflow for beta-branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 3.6-24.04/edge
+      - 3.6-24.04/beta
 
 jobs:
   ci-tests:


### PR DESCRIPTION
This PR will enhance the Github actions release workflow to release to `beta` on pushes to the `3.6-24.04/beta` branch.

After merging the PR, we will be able to release the rock to beta with just a pull request to the `3.6-24.04/beta` branch. The only change in these PR's should be an update to the `version` field in the `rockcraft.yaml`, as the rock is build from whatever snap is currently released to `3.6/beta`.