### PR TITLE
[DPE-8407] update to 3.6.5

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-etcd # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
-version: '3.6.4' # just for humans. Semantic versioning is recommended
+version: '3.6.5' # just for humans. Semantic versioning is recommended
 summary: 'etcd is a distributed reliable key-value store for distributed systems.'
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.


### PR DESCRIPTION
Update the etcd rock image to upstream release 3.6.5, release notes can be found under https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v365-2025-09-19.