### PR TITLE
chore: pin trivy action to 0.35.0

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -42,7 +42,7 @@ jobs:
               docker-daemon:trivy/charmed-etcd:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'trivy/charmed-etcd:test'
           format: 'sarif'
@@ -56,7 +56,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'image'
           format: 'spdx-json'


### PR DESCRIPTION
https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release