### PR TITLE
update to 3.6.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
             -e ETCD_ADVERTISE_CLIENT_URLS=http://localhost:2379 \
             charmed-etcd:"${version}"
           )
-          discovery_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${discovery_node}")
+          discovery_ip=$(docker inspect -f '{{ .NetworkSettings.Networks.bridge.IPAddress }}' "${discovery_node}")
 
           TOKEN="random-token"
           docker exec "${discovery_node}" etcdctl put /_etcd/registry/${TOKEN}/_config/size 3

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-etcd # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
-version: '3.6.10' # just for humans. Semantic versioning is recommended
+version: '3.6.11' # just for humans. Semantic versioning is recommended
 summary: 'etcd is a distributed reliable key-value store for distributed systems.'
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.


### PR DESCRIPTION
security fixes / bugfix

for details see https://etcd.io/blog/2026/may-patch-release/ and the [changelog](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md).

Also adjusts the test because the output of `docker inspect` has changed in the newest docker version installed through the snap.