### PR TITLE
[DPE-10412] Update etcd to 3.6.12

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-etcd # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
-version: '3.6.11' # just for humans. Semantic versioning is recommended
+version: '3.6.12' # just for humans. Semantic versioning is recommended
 summary: 'etcd is a distributed reliable key-value store for distributed systems.'
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.


### PR DESCRIPTION
Upstream etcd has released version `3.6.12`, which includes a bugfix for accidentally promoting learning members to full voting members before full data transfer. For the changelog see here: https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v3612-2026-06-01.