### PR TITLE
[DPE-10516] release 3.6.13 to stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
             -e ETCD_ADVERTISE_CLIENT_URLS=http://localhost:2379 \
             charmed-etcd:"${version}"
           )
-          discovery_ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "${discovery_node}")
+          discovery_ip=$(docker inspect -f '{{ .NetworkSettings.Networks.bridge.IPAddress }}' "${discovery_node}")
 
           TOKEN="random-token"
           docker exec "${discovery_node}" etcdctl put /_etcd/registry/${TOKEN}/_config/size 3

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-etcd # the name of your ROCK
 base: ubuntu@24.04 # the base environment for this ROCK
 license: Apache-2.0
-version: '3.6.7' # just for humans. Semantic versioning is recommended
+version: '3.6.13' # just for humans. Semantic versioning is recommended
 summary: 'etcd is a distributed reliable key-value store for distributed systems.'
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.


### PR DESCRIPTION
This PR will publish the `charmed-etcd` rock in version 3.6.13 to the `stable` risk.